### PR TITLE
update vscode settings.json to format file on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,13 +14,16 @@
     "**/.factorypath": true,
     "**/*~": true
   },
+  "editor.formatOnSave": true,
   "java.test.config": [
     {
       "name": "WPIlibUnitTests",
       "workingDirectory": "${workspaceFolder}/build/jni/release",
-      "vmargs": [ "-Djava.library.path=${workspaceFolder}/build/jni/release" ],
+      "vmargs": [
+        "-Djava.library.path=${workspaceFolder}/build/jni/release"
+      ],
       "env": {
-        "LD_LIBRARY_PATH": "${workspaceFolder}/build/jni/release" ,
+        "LD_LIBRARY_PATH": "${workspaceFolder}/build/jni/release",
         "DYLD_LIBRARY_PATH": "${workspaceFolder}/build/jni/release"
       }
     },


### PR DESCRIPTION
This should lead to formatting consistency with all files in this repo (as they are updated and saved), helping with readability

TODO:
- Make sure the windows machines with java/wpilib already installed will support formatting out of the box. My mac wanted me to install Java/another extension to be able to format. I don't think windows machines that are already setup need this